### PR TITLE
Binary tree stresstest

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We expect the list of benchmarks to change over time, but for now we have the fo
 ### list.jl
 ### tree.jl
 ### strings.jl
+### tree_immutable.jl (perfect binary tree)
+### tree_mutable.jl (perfect binary tree)
 
 ## The results
 

--- a/benches/binary_tree/tree_immutable.jl
+++ b/benches/binary_tree/tree_immutable.jl
@@ -1,0 +1,52 @@
+module BinaryTreeImmutable
+
+# Adopted from
+# https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/binarytrees.html#binarytrees
+
+using Base.Threads
+using Printf
+
+struct Node
+    l::Union{Nothing, Node}
+    r::Union{Nothing, Node}
+end
+
+function make(n::Int)
+    return n === 0 ? Node(nothing, nothing) : Node(make(n-1), make(n-1))
+end
+
+function check(node::Node)
+    return  1 + (node.l === nothing ? 0 : check(node.l) + check(node.r))
+end
+
+function binary_trees(io, n::Int)
+    @printf io "stretch tree of depth %jd\t check: %jd\n" n+1 check(make(n+1))
+
+    long_tree = make(n)
+    minDepth = 4
+    resultSize = div((n - minDepth), 2) + 1
+    results = Vector{String}(undef, resultSize)
+    Threads.@threads for depth in minDepth:2:n
+        c = 0
+        niter = 1 << (n - depth + minDepth)
+        for _ in 1:niter
+            c += check(make(depth))
+        end
+        index = div((depth - minDepth),2) + 1
+        results[index] = @sprintf "%jd\t trees of depth %jd\t check: %jd\n" niter depth c
+    end
+
+    for i in results
+        write(io, i)
+    end
+
+    @printf io "long lived tree of depth %jd\t check: %jd\n" n check(long_tree)
+end
+
+end #module
+
+include("../../utils.jl")
+
+using .BinaryTreeImmutable
+
+@gctime BinaryTreeImmutable.binary_trees(devnull, 21)

--- a/benches/binary_tree/tree_mutable.jl
+++ b/benches/binary_tree/tree_mutable.jl
@@ -1,0 +1,52 @@
+module BinaryTreeMutable
+
+# Adopted from
+# https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/binarytrees.html#binarytrees
+
+using Base.Threads
+using Printf
+
+mutable struct Node
+    l::Union{Nothing, Node}
+    r::Union{Nothing, Node}
+end
+
+function make(n::Int)
+    return n === 0 ? Node(nothing, nothing) : Node(make(n-1), make(n-1))
+end
+
+function check(node::Node)
+    return  1 + (node.l === nothing ? 0 : check(node.l) + check(node.r))
+end
+
+function binary_trees(io, n::Int)
+    @printf io "stretch tree of depth %jd\t check: %jd\n" n+1 check(make(n+1))
+
+    long_tree = make(n)
+    minDepth = 4
+    resultSize = div((n - minDepth), 2) + 1
+    results = Vector{String}(undef, resultSize)
+    Threads.@threads for depth in minDepth:2:n
+        c = 0
+        niter = 1 << (n - depth + minDepth)
+        for _ in 1:niter
+            c += check(make(depth))
+        end
+        index = div((depth - minDepth),2) + 1
+        results[index] = @sprintf "%jd\t trees of depth %jd\t check: %jd\n" niter depth c
+    end
+
+    for i in results
+        write(io, i)
+    end
+
+    @printf io "long lived tree of depth %jd\t check: %jd\n" n check(long_tree)
+end
+
+end #module
+
+include("../../utils.jl")
+
+using .BinaryTreeMutable
+
+@gctime BinaryTreeMutable.binary_trees(devnull, 21)


### PR DESCRIPTION
As discussed on Slack! Let me know if you want this structured differently or have these two share code. I keep them seperated for now to not introduce any unnecessary variables from dispatch/inference optimizing differently or similar. I also fixed a bug in the `run_one_benchmark.jl`, where it didn't pick a default value if only the single benchmark was supplied.

Also unsure whether `@threads` should be here - I had it in my initial test/finding, but maybe it just adds unnecessary noise here.

CC: @vchuravy 