### PR TITLE
robustify `@gctime`

### DIFF
--- a/utils.jl
+++ b/utils.jl
@@ -8,16 +8,26 @@ macro gctime(ex)
         :()
     quote
         $fc
-        local start_gc_num = Base.gc_num()
-        local start_time = time_ns()
-        local val = $(esc(ex))
-        local end_time = time_ns()
-        local end_gc_num = Base.gc_num()
-        result = (
-            value = val,
-            times = (end_time - start_time),
-            stats = Base.GC_Diff(end_gc_num, start_gc_num),
-        )
+        local result
+        try
+            local start_gc_num = Base.gc_num()
+            local start_time = time_ns()
+            local val = $(esc(ex))
+            local end_time = time_ns()
+            local end_gc_num = Base.gc_num()
+            result = (
+                value = val,
+                times = (end_time - start_time),
+                stats = Base.GC_Diff(end_gc_num, start_gc_num),
+            )
+        catch e
+            @show e
+            result = (
+                value = e,
+                times = NaN,
+                stats = Base.GC_Diff(Base.gc_num(), start_gc_num),
+            )
+        end
         "SERIALIZE" in ARGS ? serialize(stdout, result) : display(result)
     end
 end


### PR DESCRIPTION
This will now be much less broken if the code being timed throws an exception.