### PR TITLE
communicate over fd 3

### DIFF
--- a/utils.jl
+++ b/utils.jl
@@ -30,6 +30,11 @@ macro gctime(ex)
                 gc_end = end_gc_num
             )
         end
-        "SERIALIZE" in ARGS ? serialize(stdout, result) : display(result)
+        if "SERIALIZE" in ARGS
+            # uglyness to communicate over non stdout (specifically file descriptor 3)
+            serialize(open(RawFD(3)), result)
+        else
+            display(result)
+        end
     end
 end


### PR DESCRIPTION
This makes it so stdout and stderr can be used by the child processes (eg for debugging). Major thanks to @vtjnash for patiently and repeatedly explaining how to make this work.