### PR TITLE
Cross binary comparison

### DIFF
--- a/compare_bins.jl
+++ b/compare_bins.jl
@@ -1,0 +1,43 @@
+const doc = """compare_bin.jl -- Cross binary comparison between GC benchmarks
+Usage:
+    compare_bins.jl <json1> <json2>
+Options:
+    -h, --help                            Show this screen.
+"""
+
+using DocOpt
+using JSON
+using PrettyTables
+
+const args = docopt(doc, version = v"0.1.1")
+
+function main(args)
+    f1 = args["<json1>"]
+    f2 = args["<json2>"]
+
+    js1 = JSON.parsefile(f1)
+    js2 = JSON.parsefile(f2)
+
+    labels = ["total time ",
+              "gc time ",
+              "mark time",
+              "sweep time",
+              "max pause",
+              "max memory",
+              "pct gc"]
+    header = ["", f1, f2]
+
+    # show medians
+    raw_data = [js1["total time"][1] js2["total time"][2];
+                js1["gc time"][1] js2["gc time"][2];
+                js1["mark time"][1] js2["mark time"][2];
+                js1["sweep time"][1] js2["sweep time"][2];
+                js1["max pause"][1] js2["max pause"][2];
+                js1["max memory"][1] js2["max memory"][2];
+                js1["pct gc"][1] js2["pct gc"][2]]
+
+    data = hcat(labels, raw_data)
+    pretty_table(data, header, formatters=ft_printf("%0.0f"))
+end
+
+main(args)

--- a/run_benchmarks.jl
+++ b/run_benchmarks.jl
@@ -9,11 +9,13 @@ Options:
     -s <max>, --scale=<max>               Maximum number of threads for scaling test.
     -h, --help                            Show this screen.
     --version                             Show version.
+    --json                                Serializes output to `json` file
 """
 
 using DocOpt
 using PrettyTables
 using Printf
+using JSON
 using Serialization
 using Statistics
 
@@ -38,7 +40,7 @@ function highlight_col(col, lo, hi)
      Highlighter((data,i,j) -> (j == col) && hi <= data[i, j]; foreground=:red),]
 end
 
-function run_bench(runs, threads, file)
+function run_bench(runs, threads, file, show_json = false)
     value = []
     times = []
     gc_diff = []
@@ -72,37 +74,49 @@ function run_bench(runs, threads, file)
     append!(highlighters, highlight_col(5, 1, 10)) # time to safepoint
     append!(highlighters, highlight_col(7, 10, 50)) # pct gc
     highlighters = Tuple(highlighters)
-    data = hcat(labels, total_stats, gc_time, mark_time, sweep_time, max_pause, time_to_safepoint, max_mem, pct_gc)
-    pretty_table(data; header, formatters=ft_printf("%0.0f"), highlighters)
+    if show_json
+        data = Dict([("total time", total_stats),
+                     ("gc time", gc_time),
+                     ("mark time", mark_time),
+                     ("sweep time", sweep_time),
+                     ("max pause", max_pause),
+                     ("ttsp", time_to_safepoint),
+                     ("max memory", max_mem),
+                     ("pct gc", pct_gc)])
+        JSON.print(data)
+    else
+        data = hcat(labels, total_stats, gc_time, mark_time, sweep_time, max_pause, time_to_safepoint, max_mem, pct_gc)
+        pretty_table(data; header, formatters=ft_printf("%0.0f"), highlighters)
+    end
 end
 
-function run_category_files(benches, args)
+function run_category_files(benches, args, show_json = false)
     local runs = parse(Int, args["--runs"])
     local threads = parse(Int, args["--threads"])
     local max = if isnothing(args["--scale"]) 0 else parse(Int, args["--scale"]) end
     for bench in benches
         @show bench
         if isnothing(args["--scale"])
-            run_bench(runs, threads, bench)
+            run_bench(runs, threads, bench, show_json)
         else
             local n = 0
             while true
                 threads = 2^n
                 threads > max && break
                 @show threads
-                run_bench(runs, threads, bench)
+                run_bench(runs, threads, bench, show_json)
                 n += 1
             end
         end
     end
 end
 
-function run_all_categories(args)
+function run_all_categories(args, show_json = false)
     for category in readdir()
         @show category
         cd(category)
         benches = filter(f -> endswith(f, ".jl"), readdir())
-        run_category_files(benches, args)
+        run_category_files(benches, args, show_json)
         cd("..")
     end
 end
@@ -124,8 +138,10 @@ function main(args)
         cd("slow")
     end
 
+    show_json = !isnothing(args["--json"])
+
     if args["all"]
-        run_all_categories(args)
+        run_all_categories(args, show_json)
     else
         cd(args["<category>"])
         benches = if isnothing(args["<name>"])
@@ -133,7 +149,7 @@ function main(args)
         else
             ["$(args["<name>"]).jl"]
         end
-        run_category_files(benches, args)
+        run_category_files(benches, args, show_json)
     end
 end
 

--- a/run_benchmarks.jl
+++ b/run_benchmarks.jl
@@ -13,9 +13,9 @@ Options:
 """
 
 using DocOpt
+using JSON
 using PrettyTables
 using Printf
-using JSON
 using Serialization
 using Statistics
 
@@ -95,7 +95,9 @@ function run_category_files(benches, args, show_json = false)
     local threads = parse(Int, args["--threads"])
     local max = if isnothing(args["--scale"]) 0 else parse(Int, args["--scale"]) end
     for bench in benches
-        @show bench
+        if !show_json
+            @show bench
+        end
         if isnothing(args["--scale"])
             run_bench(runs, threads, bench, show_json)
         else


### PR DESCRIPTION
Example of usage:

```
$JULIA_BIN run_benchmarks.jl serial linked tree -n1 --json > out1
$JULIA_BIN run_benchmarks.jl serial linked tree -n1 --json > out2
$JULIA_BIN compare_bins.jl out1 out2 
```

I found it more convenient to connect `run_benchmarks.jl` and `compare_bins.jl` through a shell script. But could be done on `julia` itself.