### PR TITLE
lower bound overhead

### DIFF
--- a/lower_bound_overhead.jl
+++ b/lower_bound_overhead.jl
@@ -25,7 +25,6 @@ function main(args)
         # using medians
         total_time = js["total time"][2]
         gc_time = js["gc time"][2]
-
         mdcs[file] = total_time - gc_time
     end
 
@@ -35,8 +34,6 @@ function main(args)
         js = JSON.parsefile(file)
         # using medians
         total_time = js["total time"][2]
-        gc_time = js["gc time"][2]
-
         lbos[file] = total_time - mdc
     end
 

--- a/lower_bound_overhead.jl
+++ b/lower_bound_overhead.jl
@@ -1,0 +1,50 @@
+const doc = """lower_bound_overhead.jl -- Cost metric taken from `Distilling the Real Cost of
+Production Garbage Collectors` by Cai et al.
+Usage:
+    lower_bound_overhead.jl <json>...
+Options:
+    -h, --help                            Show this screen.
+"""
+
+using DocOpt
+using JSON
+using PrettyTables
+
+const args = docopt(doc, version = v"0.1.1")
+
+function main(args)
+    files = args["<json>"]
+
+    # minimum distilled costs
+    local mdcs = Dict{String, Float64}()
+    #lower bound overheads
+    local lbos = Dict{String, Float64}()
+
+    for file in files
+        js = JSON.parsefile(file)
+        # using medians
+        total_time = js["total time"][2]
+        gc_time = js["gc time"][2]
+
+        mdcs[file] = total_time - gc_time
+    end
+
+    mdc = reduce(min, values(mdcs))
+
+    for file in files
+        js = JSON.parsefile(file)
+        # using medians
+        total_time = js["total time"][2]
+        gc_time = js["gc time"][2]
+
+        lbos[file] = total_time - mdc
+    end
+
+    labels = ["lower bound overhead [ms]"]
+    header = [""; files]
+    raw_data = [lbos[file] for file in files]
+    data = hcat(labels, raw_data')
+    pretty_table(data, header, formatters=ft_printf("%0.0f"))
+end
+
+main(args)


### PR DESCRIPTION
Computes the lower bound overhead metric from "Distilling the Real Cost of Production Garbage Collectors" by Cai et al.

Example of usage:

```
$JULIA_BIN run_benchmarks.jl serial linked tree -n1 --json > out1
$JULIA_BIN run_benchmarks.jl serial linked tree -n1 --json > out2
$JULIA_BIN run_benchmarks.jl serial linked tree -n1 --json > out3
$JULIA_BIN lower_bound_overhead.jl out1 out2 out3
``` 

Example of output:

```
┌───────────────────────────┬──────┬──────┬──────┐
│                           │ out1 │ out2 │ out3 │
├───────────────────────────┼──────┼──────┼──────┤
│ lower bound overhead [ms] │  341 │  814 │  344 │
└───────────────────────────┴──────┴──────┴──────┘
```

I find it more convenient to connect everything through a shell script, but could be done on a single `julia` file.

The metric computed by the functionality in this PR is wall clock time. Not sure how to parse cache misses/cycles from `perf`, but could be done in the future as well.