### PR TITLE
HW counters/lower-bound-overhead

### DIFF
--- a/hw_measurements.jl
+++ b/hw_measurements.jl
@@ -1,0 +1,106 @@
+const doc = """hw_measurements.jl -- Computes `lower-bound-overhead` from Cai et al.
+Hardware counters are measured with `perf`
+Usage:
+    hw_measurements.jl <path_to_bin1> <path_to_bin2> <path_to_benchmark>
+Options:
+    -h, --help                            Show this screen.
+"""
+
+using DocOpt
+using JSON
+using PrettyTables
+using Printf
+
+const args = docopt(doc, version = v"0.1.1")
+
+const EVENT_INDEX = 4
+const FUNC_NAME_INDEX = 7
+
+# We're missing a few `libc` (e.g. `free`) functions that are called from sweeping
+# This shouldn't matter if we are comparing the lower bound overhead accross
+# binaries that differ only in the mark-loop code
+function match_gc_function(func_name)
+   return occursin("sweep", func_name) || (occursin("gc_", func_name) && !occursin("alloc", func_name) && !occursin("finalizer", func_name))
+end
+
+function parse_event_table(perf_script_file)
+    gc_event_count = 0
+    total_event_count = 0
+    lines = readlines(perf_script_file)
+    for l in lines
+        l_filtered = filter(x -> x != "", collect(eachsplit(l, " ")))
+        event_count = l_filtered[EVENT_INDEX]
+        func_name = l_filtered[FUNC_NAME_INDEX]
+        if match_gc_function(func_name)
+            gc_event_count += parse(Int64, event_count)
+        end
+        total_event_count += parse(Int64, event_count)
+    end
+    return gc_event_count, total_event_count
+end
+
+event_list = ["cycles", "instructions", "cache-misses", "page-faults"]
+
+function run_benchmark(bin_list, f)
+    if !Sys.islinux()
+        error("Measurement infrastructure is `only available on linux")
+    end
+
+    # Initialize event count tables
+    gc_event_counts = Dict()
+    total_event_counts = Dict()
+    for event in event_list
+        gc_event_counts[event] = []
+        total_event_counts[event] = []
+    end
+    
+    f_split = collect(eachsplit(f, "/"))
+    directory = f_split[3]
+    category = f_split[4]
+    # remove trailing `.jl` extension
+    file_name = collect(eachsplit(f_split[5], "."))[1]
+    for bin in bin_list
+        Printf.@printf "Running %s on %s\n" f_split[5] bin
+        for event in event_list
+            Printf.@printf "Measuring %s\n" event
+            run(pipeline(`perf record -e $event $bin run_benchmarks.jl $directory $category $file_name`, stdout = devnull, stderr = devnull))
+            run(pipeline(`perf script`, stdout = "out"))
+            gc_event_count, total_event_count = parse_event_table("out")
+            push!(gc_event_counts[event], gc_event_count)
+            push!(total_event_counts[event], total_event_count)
+        end
+    end
+    
+    return gc_event_counts, total_event_counts
+end
+
+function build_table(bin_list, f)
+    header = ["" bin_list]
+
+    gc_event_counts, total_event_counts = run_benchmark(bin_list, f)
+
+    # compute distilled costs and lower bound overheads
+    for event in event_list
+        distilled_costs = []
+        for (i, _) in enumerate(bin_list)
+            push!(distilled_costs, total_event_counts[event][i] - gc_event_counts[event][i])
+        end
+        minimum_distilled_cost = reduce(min, distilled_costs)
+        lower_bound_overheads = ["LBO in $event"]
+        for (i, _) in enumerate(bin_list)
+            lower_bound_overheads = hcat(lower_bound_overheads, string(total_event_counts[event][i] - minimum_distilled_cost))
+        end
+        header = vcat(header, lower_bound_overheads)
+    end
+
+    pretty_table(header[2:end, :], header[1, :])
+end
+
+function main(args)
+    bin1 = args["<path_to_bin1>"]
+    bin2 = args["<path_to_bin2>"]
+    benchmark = args["<path_to_benchmark>"]
+    build_table([bin1 bin2], benchmark)
+end
+
+main(args)

--- a/hw_measurements.jl
+++ b/hw_measurements.jl
@@ -13,6 +13,7 @@ using Printf
 
 const args = docopt(doc, version = v"0.1.1")
 
+const NRUNS = 10
 const EVENT_INDEX = 4
 const FUNC_NAME_INDEX = 7
 
@@ -43,7 +44,7 @@ event_list = ["cycles", "instructions", "cache-misses", "page-faults"]
 
 function run_benchmark(bin_list, f)
     if !Sys.islinux()
-        error("Measurement infrastructure is `only available on linux")
+        error("Measurement infrastructure is only available on linux")
     end
 
     # Initialize event count tables
@@ -63,9 +64,9 @@ function run_benchmark(bin_list, f)
         Printf.@printf "Running %s on %s\n" f_split[5] bin
         for event in event_list
             Printf.@printf "Measuring %s\n" event
-            run(pipeline(`perf record -e $event $bin run_benchmarks.jl $directory $category $file_name`, stdout = devnull, stderr = devnull))
+            run(pipeline(`perf record -e $event $bin run_benchmarks.jl $directory $category $file_name -n$NRUNS`, stdout = devnull, stderr = devnull))
             run(pipeline(`perf script`, stdout = "out"))
-            gc_event_count, total_event_count = parse_event_table("out")
+            gc_event_count, total_event_count = parse_event_table("out") ./ NRUNS
             push!(gc_event_counts[event], gc_event_count)
             push!(total_event_counts[event], total_event_count)
         end


### PR DESCRIPTION
Piggybacks on `perf` to aggregate hardware counters and compute lower-bound-overhead from Cai et al ("Distilling the Real Cost of Production Garbage Collectors").

Example of usage:

```
../julia_master/julia hw_measurements.jl "../julia_master/julia" "../julia_pr/julia" "./benches/serial/bigint/pollard.jl"
```

Example of output:

```
Running pollard.jl on ../julia_master/julia
Measuring cycles
Measuring instructions
Measuring cache-misses
Measuring page-faults
Running pollard.jl on ../julia_pr/julia
Measuring cycles
Measuring instructions
Measuring cache-misses
Measuring page-faults
┌─────────────────────┬───────────────────────┬──────────────────────┐
│                     │ ../julia_master/julia │    ../julia_pr/julia │
├─────────────────────┼───────────────────────┼──────────────────────┤
│       LBO in cycles │  1.4050708230999985e9 │ 1.1315522388999996e9 │
│ LBO in instructions │  2.0782619566000023e9 │ 1.9208291789000015e9 │
│ LBO in cache-misses │   6.552438599999998e6 │ 5.8233013999999985e6 │
│  LBO in page-faults │     17403.79999999999 │   10940.899999999994 │
└─────────────────────┴───────────────────────┴──────────────────────┘

```

Cycles, instructions, cache-misses and page-faults are measured for now, but can easily be extended to a larger set of hardware counters measured by `perf`.

Only works on `linux`.