### PR TITLE
Add necessary deps to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,3 +1,7 @@
 [deps]
 DocOpt = "968ba79b-81e4-546f-ab3a-2eecfa62a9db"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"


### PR DESCRIPTION
These dependencies are used in `run_benchmarks.jl`, but for some reason aren't present in the Project.toml.

This fixes that.