### PR TITLE
use fixed size for arrays in obj_arrays benchmarks

### DIFF
--- a/benches/serial/obj_arrays/many_refs.jl
+++ b/benches/serial/obj_arrays/many_refs.jl
@@ -24,8 +24,8 @@ end #module
 
 using .ManyRef
 
-const MAX_MEMORY = round(Int, 0.8 * Sys.total_memory())
+const GB = 1<<30
+const MAX_MEMORY = round(Int, 0.8 * GB)
 const array_length = div(MAX_MEMORY, 3*sizeof(Ptr{C_NULL}))
 
-@info "ManyRef bench" array_length MAX_MEMORY
 @gctime ManyRef.construct(array_length)

--- a/benches/serial/obj_arrays/single_ref.jl
+++ b/benches/serial/obj_arrays/single_ref.jl
@@ -21,8 +21,8 @@ end #module
 
 using .SingleRef
 
-const MAX_MEMORY = round(Int, 0.8 * Sys.total_memory())
+const GB = 1<<30
+const MAX_MEMORY = round(Int, 0.8 * GB)
 const array_length = div(MAX_MEMORY, sizeof(Ptr{C_NULL}))
 
-@info "SingleRef bench" array_length MAX_MEMORY
 @gctime SingleRef.construct(array_length)


### PR DESCRIPTION
Benchmark currently takes too long on machines with ~100GB memory.