### PR TITLE
Fixed amount of work for rb_tree.jl

### DIFF
--- a/benches/slow/rb_tree/rb_tree.jl
+++ b/benches/slow/rb_tree/rb_tree.jl
@@ -66,9 +66,7 @@ struct PointByY
 end
 Base.isless(a::PointByY, b::PointByY) = isless(a.p.y, b.p.y)
 
-function tvbench(; N = 100_000_000, min_seconds = 0, max_seconds = 1000)
-    @assert min_seconds <= max_seconds
-
+function tvbench(; N = 10_000_000)
     t0 = time()
     queue = Queue{Point}()
     xtree = RBTree{PointByX}()
@@ -99,7 +97,7 @@ function tvbench(; N = 100_000_000, min_seconds = 0, max_seconds = 1000)
                 tcheck = tcheck2
                 println("elapsed=$(elapsed)s, $(length(queue)) current points, $(count) total, $(floor(count/elapsed)) per second")
             end
-            if (elapsed >= min_seconds) && ((count >= N) || (elapsed >= max_seconds))
+            if (count >= N)
                 break
             end
 	end

--- a/benches/slow/rb_tree/rb_tree.jl
+++ b/benches/slow/rb_tree/rb_tree.jl
@@ -66,7 +66,7 @@ struct PointByY
 end
 Base.isless(a::PointByY, b::PointByY) = isless(a.p.y, b.p.y)
 
-function tvbench(; N = 20_000_000)
+function tvbench(; N = 50_000_000)
     t0 = time()
     queue = Queue{Point}()
     xtree = RBTree{PointByX}()

--- a/benches/slow/rb_tree/rb_tree.jl
+++ b/benches/slow/rb_tree/rb_tree.jl
@@ -66,7 +66,7 @@ struct PointByY
 end
 Base.isless(a::PointByY, b::PointByY) = isless(a.p.y, b.p.y)
 
-function tvbench(; N = 10_000_000)
+function tvbench(; N = 20_000_000)
     t0 = time()
     queue = Queue{Point}()
     xtree = RBTree{PointByX}()


### PR DESCRIPTION
I believe the previous version was imposing a time cutoff for the benchmark.

This PR eliminates the time cutoffs and sets a lower iteration count.

`N=10_000_000` was chosen in order to make the benchmark last ~1min on my machine:

```
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │      84248 │   11706 │     11431 │        276 │         3330 │                 9 │     1010 │         14 │
│  median │      84248 │   11706 │     11431 │        276 │         3330 │                 9 │     1010 │         14 │
│ maximum │      84248 │   11706 │     11431 │        276 │         3330 │                 9 │     1010 │         14 │
│   stdev │        NaN │     NaN │       NaN │        NaN │          NaN │               NaN │      NaN │        NaN │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```