### PR TITLE
Use mem pressure callbacks to find minimum heap size to run a benchmark

### DIFF
--- a/runs-with-heap-size.sh
+++ b/runs-with-heap-size.sh
@@ -1,0 +1,12 @@
+JULIA_BIN=$1
+HEAP_SIZE=$2
+BENCHMARK=$3
+
+$JULIA_BIN --heap-size-hint=$HEAP_SIZE $BENCHMARK
+
+if [ $? -ne 0 ]; then
+    echo "Failed to run $BENCHMARK with heap size $HEAP_SIZE"
+    exit 1
+fi
+
+echo "Successfully ran $BENCHMARK with heap size $HEAP_SIZE"


### PR DESCRIPTION
Usage:

```
bash ./runs-with-heap-size.sh <julia> <heap-size> <benchmark>
````

Where `heap-size` has to be essentially bisected.