### PR TITLE
Do a GC run before running the benchmarks

### DIFF
--- a/utils.jl
+++ b/utils.jl
@@ -30,6 +30,7 @@ macro gctime(ex)
     quote
         $fc
         local result
+        GC.gc()
         local start_gc_num = Base.gc_num()
         local end_gc_num = start_gc_num
         local start_time = time_ns()
@@ -46,6 +47,7 @@ macro gctime(ex)
                 gc_end = end_gc_num
             )
         catch e
+            print("EXCEPTION???")
             @show e
             result = (;
                 value = e,


### PR DESCRIPTION
When I was running the benchmarks with MMTk, I noticed that for some reason, running it through a script would trigger GC in the benchmark, whereas running it via command line wouldn't.
The fix: making sure full GC is ran before running the benchmark to get rid of any garbage that may exist. Since this may also be a problem for the Julia GC, I'm opening this PR. 

NB: when collecting statistics via MMTk harness methods, it always does a GC before the benchmark, exactly to target this issue. However, we are using Julia's GC stats (as much as we can), and that's why it was problematic in our case.