### PR TITLE
increase amount of garbage allocated in TimeZones

### DIFF
--- a/benches/serial/TimeZones/TimeZones.jl
+++ b/benches/serial/TimeZones/TimeZones.jl
@@ -4,5 +4,5 @@ using TimeZones
 
 zdts = [now(tz"UTC") for _ in  1:100_000_000];
 
-@gctime sum(hash, ["trashfire"^min(1000, i) for i in 1:100_000])
+@gctime sum(hash, ["trashfire"^min(1000, i) for i in 1:500_000])
 


### PR DESCRIPTION
Otherwise this benchmark triggers barely no GC in some machines with larger amounts of RAM.