### PR TITLE
reduce matrix size in mm_divide_and_conquer benchmark

### DIFF
--- a/benches/multithreaded/mm_divide_and_conquer/mm_divide_and_conquer.jl
+++ b/benches/multithreaded/mm_divide_and_conquer/mm_divide_and_conquer.jl
@@ -64,7 +64,7 @@ function matrix_multiply_recursive(res, x, y)
     end
 end
 
-const M_SIZE = (1 << 14)
+const M_SIZE = (1 << 12)
 
 function main_recursive()
     m1 = rand(1:100, M_SIZE, M_SIZE)


### PR DESCRIPTION
This OOMs even on some machines with a relatively large amount of memory.