### PR TITLE
change find-all-min-heaps script to use the --hard-heap-limit flag that was recently upstreamed

### DIFF
--- a/util/find-all-min-heaps.jl
+++ b/util/find-all-min-heaps.jl
@@ -20,7 +20,7 @@ function find_min_size(bench_path)
         @info "Attempting heap size $(heap_size)MB"
         proc = run(
             pipeline(
-                `$(Base.julia_cmd()) --project=$(bench_path_parent) --heap-size-hint=$(heap_size)M $bench_path`,
+                `$(Base.julia_cmd()) --project=$(bench_path_parent) --hard-heap-limit=$(heap_size)M --gc-sweep-always-full $bench_path`,
                 stdout = stdout,
                 stderr = stderr,
             );


### PR DESCRIPTION
Depends on https://github.com/JuliaLang/julia/pull/58713.

To test this change, I ran the script to determine the minimum heap size required to run the inference benchmark (850MB).