### PR TITLE
Lock PrettyTables version, allow some gc stats missing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,3 +8,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+
+[compat]
+PrettyTables = "2"

--- a/run_benchmarks.jl
+++ b/run_benchmarks.jl
@@ -44,8 +44,8 @@ function highlight_col(col, lo, hi)
 end
 
 function diff(gc_end, gc_start, p)
-    v0 = getproperty(gc_start, p)
-    v1 = getproperty(gc_end, p)
+    v0 = hasproperty(gc_start, p) ? getproperty(gc_start, p) : 0
+    v1 = hasproperty(gc_end, p) ? getproperty(gc_end, p) : 0
     v1-v0
 end
 


### PR DESCRIPTION
Most benchmarks should run fine with these changes on Julia 1.12/1.13.
1. The dependency `PrettyTables` has breaking APIs for version 3. Set `PrettyTables` version to 2.
2. GC stats might be different from version to version, fallback to 0 if the property to read does not exist.