### PR TITLE
Add method_churn: type inference as a GC workload

### DIFF
--- a/benches/compiler/inference/method_churn.jl
+++ b/benches/compiler/inference/method_churn.jl
@@ -1,0 +1,82 @@
+include(joinpath("..", "..", "..", "util", "utils.jl"))
+
+# Uses the compiler itself as the GC workload: repeatedly define *fresh* methods
+# (gensym'd names, so nothing is ever cached from a previous iteration) and run
+# type inference + optimization over them with `code_typed`.
+#
+# This is the allocation profile of loading a package or a REPL session - a mix
+# of Exprs, CodeInfos, IR, type objects and caches - rather than the
+# uniform data structures most GC benchmarks are made of. Unlike
+# inference_benchmarks.jl, which measures the *compiler's speed* on pathological
+# inputs, this measures the *GC* under the compiler's allocation behaviour.
+
+module MethodChurn
+
+# Six leaf-body shapes exercising different parts of inference: containers,
+# strings, unions, broadcasting, closures, tuples.
+function leaf_body(kind::Int)
+    kind == 1 && return :(begin v = [k * 0.5 for k in 1:n]; sum(sort!(v)) end)
+    kind == 2 && return :(length(join(string.(1:n), ",")))
+    kind == 3 && return :(begin d = Dict{Int,String}()
+                                for k in 1:n; d[k] = string(k); end
+                                length(d) end)
+    kind == 4 && return :(begin x = n > 0 ? n : nothing
+                                x === nothing ? 0 : x + 1 end)
+    kind == 5 && return :(begin f = k -> k * n; sum(map(f, 1:n)) end)
+    return :(begin t = (a = n, b = string(n), c = (n, n + 1))
+                   t.a + t.c[2] + length(t.b) end)
+end
+
+# One "unit" is a call tree of nine fresh methods: six leaves, two mids that
+# call three leaves each, and a top that calls both mids in a loop. Inferring
+# the top infers the whole fresh graph.
+function define_unit()
+    leaves = [gensym(:leaf) for _ in 1:6]
+    mids = [gensym(:mid) for _ in 1:2]
+    top = gensym(:top)
+    defs = Expr(:block)
+    for (j, f) in enumerate(leaves)
+        push!(defs.args, :(function $f(n::Int); $(leaf_body(j)); end))
+    end
+    for (j, m) in enumerate(mids)
+        l1, l2, l3 = leaves[3j-2], leaves[3j-1], leaves[3j]
+        push!(defs.args, :(function $m(n::Int)
+            $l1(n) + $l2(n) + Int($l3(n) % 1000)
+        end))
+    end
+    push!(defs.args, :(function $top(n::Int)
+        s = 0
+        for i in 1:n
+            s += $(mids[1])(i) + $(mids[2])(i)
+        end
+        return s
+    end))
+    Core.eval(@__MODULE__, defs)
+    return top
+end
+
+const UNITS_PER_ITER = 40
+const NITER = 5
+
+function churn()
+    inferred = 0
+    for _ in 1:NITER
+        for _ in 1:UNITS_PER_ITER
+            top = define_unit()
+            # the binding was created after this method's world: look it up and
+            # infer it in the latest world
+            f = Base.invokelatest(getglobal, @__MODULE__, top)
+            ci = Base.invokelatest(code_typed, f, (Int,))
+            inferred += length(ci)
+        end
+    end
+    return inferred
+end
+
+end # module MethodChurn
+
+# compile the reflection machinery outside the measured region
+MethodChurn.define_unit()
+code_typed(sin, (Float64,))
+
+@gctime MethodChurn.churn()


### PR DESCRIPTION
Repeatedly defines call trees of fresh `gensym`-named methods (6 leaves of varying body shapes, 2 mids, 1 top per unit; 40 units × 5 iterations) and runs `code_typed` over each top, so every iteration re-runs inference and optimization from scratch.

**Why this earns a slot next to `inference_benchmarks.jl`:** both exercise the GC under the compiler's allocation profile, and they are about equally GC-bound — measured on Julia 1.12.6, this runs ~6 s with ~2.8 GB allocated at ~10% GC time, while `inference_benchmarks.jl` runs ~18 s with ~8.9 GB at ~10–11% GC time (near-identical allocation rates, ~0.47 vs ~0.49 GB/s, mark/sweep split ~60/40 in both). The differences are in benchmark quality rather than GC fraction:

- **No cache reuse.** `inference_benchmarks.jl` runs a fixed target set against caches that fill as it goes (several of its targets specifically measure caching, e.g. `CachedMethodTable`, GlobalRef caching). Fresh gensym'd methods make every iteration identical work, so the GC load is steady and repeatable.
- **Scalable.** `UNITS_PER_ITER` / `NITER` scale the workload linearly; the fixed suite does not.
- **~3× shorter** at the same allocation rate, which matters when the harness runs each benchmark 10 times per configuration.
- **Generic shapes**, not the compiler-pathology stressers — for GC purposes the mainstream allocation behaviour is the signal.

Uses `invokelatest` for the post-`eval` binding lookups, so it is clean under 1.12's strict binding world-age semantics.

Disclosure: this PR was written with the assistance of generative AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)