### PR TITLE
ci: test on latest release; make nightly allowed to fail

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,14 +14,19 @@ jobs:
     name: Julia ${{ matrix.version }} -- ${{ matrix.benchmark }} -- ${{ matrix.category }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # nightly may break; only the release version is required to pass
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     if: "!contains(github.event.head_commit.message, '[skip tests]')"
     strategy:
       fail-fast: false
       matrix:
-        version: ["nightly"]
+        version: ["1", "nightly"]
         benchmark: ["serial", "multithreaded"]
         category: ["all"]
         include:
+          - version: "1"
+            benchmark: "slow"
+            category: "bigint"
           - version: "nightly"
             benchmark: "slow"
             category: "bigint"


### PR DESCRIPTION
Run the benchmark matrix on both the latest stable Julia ("1") and nightly. Nightly jobs get continue-on-error so an upstream regression (e.g. the transient harness segfault seen on nightly) does not turn CI red; the release jobs are the required signal.